### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Startuj.AI Workflows
 
-Ten repozytorium zawiera instrukcje do stworzenia dwóch workflowów w Dify. Szczegóły każdego z nich znajdziesz w katalogu [`docs/`](docs/):
+To repozytorium zawiera instrukcje do stworzenia dwóch workflowów w Dify. Szczegóły każdego z nich znajdziesz w katalogu [`docs/`](docs/):
 
 - [`outline_builder.md`](docs/outline_builder.md) – opis generowania szkieletu kursu.
 - [`lesson_pipeline.md`](docs/lesson_pipeline.md) – opis codziennej produkcji lekcji na bazie zamrożonego outline.


### PR DESCRIPTION
## Summary
- update wording in the README to use correct form "To repozytorium"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ba7ceff4832583baeaeb9324b1db